### PR TITLE
Add Abomonation impl for Result<T, E>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,27 @@ impl<T: Abomonation> Abomonation for Option<T> {
     }
 }
 
+impl<T: Abomonation, E: Abomonation> Abomonation for Result<T, E> {
+    #[inline] unsafe fn embalm(&mut self) {
+        match self {
+            &mut Ok(ref mut inner) => inner.embalm(),
+            &mut Err(ref mut inner) => inner.embalm(),
+        }
+    }
+    #[inline] unsafe fn entomb(&self, bytes: &mut Vec<u8>) {
+        match self {
+            &Ok(ref inner) => inner.entomb(bytes),
+            &Err(ref inner) => inner.entomb(bytes),
+        }
+    }
+    #[inline] unsafe fn exhume<'a, 'b>(&'a mut self, mut bytes: &'b mut[u8]) -> Option<&'b mut [u8]> {
+        match self {
+            &mut Ok(ref mut inner) => inner.exhume(bytes),
+            &mut Err(ref mut inner) => inner.exhume(bytes),
+        }
+    }
+}
+
 tuple_abomonate!(A);
 tuple_abomonate!(A B);
 tuple_abomonate!(A B C);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,7 @@ use abomonation::*;
 
 #[test] fn test_array() { _test_pass(vec![[0, 1, 2]; 1024]); }
 #[test] fn test_opt_vec() { _test_pass(vec![Some(vec![0,1,2]), None]); }
+#[test] fn test_result_vec_str() { _test_pass(vec![Ok(vec![0, 1, 2]), Err("grawwwwrr!"), Ok(vec![])]); }
 #[test] fn test_str_ref() { _test_pass(vec!["hi there"; 245]); }
 #[test] fn test_alignment() { _test_pass(vec![(format!("x"), vec![1,2,3]); 1024]); }
 #[test] fn test_option_box_u64() { _test_pass(vec![Some(Box::new(0u64))]); }


### PR DESCRIPTION
Does what it says on the tin. :) 

Since `Option<T>` is already there, and one cannot simply implement it in other crates without wrappers because of Rust's orphan rules.