### PR TITLE
Implement Abomonation for PhantomData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 
 use std::mem;       // yup, used pretty much everywhere.
 use std::io::Write; // for bytes.write_all; push_all is unstable and extend is slow.
+use std::marker::PhantomData;
 
 const EMPTY: *mut () = 0x1 as *mut ();
 
@@ -293,6 +294,8 @@ impl Abomonation for bool { }
 impl Abomonation for () { }
 
 impl Abomonation for char { }
+
+impl<T> Abomonation for PhantomData<T> {}
 
 impl<T: Abomonation> Abomonation for Option<T> {
     #[inline] unsafe fn embalm(&mut self) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,13 @@ use abomonation::*;
 #[test] fn test_string_fail() { _test_fail(vec![format!("grawwwwrr!"); 1024]); }
 #[test] fn test_vec_u_s_fail() { _test_fail(vec![vec![(0u64, format!("grawwwwrr!")); 32]; 32]); }
 
+#[test]
+fn test_phantom_data_for_non_abomonatable_type() {
+    use std::marker::PhantomData;
+    struct NotAbomonatable;
+    _test_pass(PhantomData::<NotAbomonatable>::default());
+}
+
 fn _test_pass<T: Abomonation+Eq>(record: T) {
     let mut bytes = Vec::new();
     unsafe { encode(&record, &mut bytes); }
@@ -27,6 +34,7 @@ fn _test_pass<T: Abomonation+Eq>(record: T) {
         assert!(rest.len() == 0);
     }
 }
+
 
 fn _test_fail<T: Abomonation>(record: T) {
     let mut bytes = Vec::new();


### PR DESCRIPTION
PhantomData is only a zero-sized type-level marker. Therefore, it should
never have an effect on serialization.

This change provides a blanket impl for the type, so that (de-)serializing it
is a no-op.