### PR TITLE
Size and Abomonated modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abomonation"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "A high performance and very unsafe serialization library"

--- a/src/abomonated.rs
+++ b/src/abomonated.rs
@@ -1,0 +1,109 @@
+
+use std::mem::transmute;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use super::{Abomonation, decode};
+
+/// A type wrapping owned decoded abomonated data.
+///
+/// This type ensures that decoding and pointer correction has already happened,
+/// and implements `Deref<Target=T>` using a pointer cast (transmute).
+///
+/// #Safety
+///
+/// The safety of this type, and in particular its `transute` implementation of 
+/// the `Deref` trait, relies on the owned bytes not being externally mutated 
+/// once provided. You could imagine a new type implementing `DerefMut` as required,
+/// but which also retains the ability (e.g. through `RefCell`) to mutate the bytes.
+/// This would be very bad, but seems hard to prevent in the type system. Please 
+/// don't do this.
+///
+/// #Examples
+///
+/// ```
+/// use std::ops::Deref;
+/// use abomonation::{encode, decode};
+/// use abomonation::abomonated::Abomonated;
+///
+/// // create some test data out of abomonation-approved types
+/// let vector = (0..256u64).map(|i| (i, format!("{}", i)))
+///                         .collect::<Vec<_>>();
+///
+/// // encode a Vec<(u64, String)> into a Vec<u8>
+/// let mut bytes = Vec::new();
+/// unsafe { encode(&vector, &mut bytes); }
+///
+/// // attempt to decode `bytes` into a `&Vec<(u64, String)>`.
+/// let maybe_decoded = unsafe { Abomonated::<Vec<(u64, String)>,_>::new(bytes) };
+///
+/// if let Some(decoded) = maybe_decoded {
+///     // each `deref()` call is now just a pointer cast.
+///     assert!(decoded.deref() == &vector);
+/// }
+/// else {
+///     panic!("failed to decode");
+/// }
+/// ```
+pub struct Abomonated<T: Abomonation, S: DerefMut<Target=[u8]>> {
+    phantom: PhantomData<T>,
+    decoded: S,
+}
+
+impl<T: Abomonation, S: DerefMut<Target=[u8]>> Abomonated<T, S> {
+
+    /// Attempts to create decoded data from owned mutable bytes.
+    ///
+    /// This method will return `None` if it is unable to decode the data with
+    /// type `T`.
+    ///
+    /// #Examples
+    ///
+    /// ```
+    /// use std::ops::Deref;
+    /// use abomonation::{encode, decode};
+    /// use abomonation::abomonated::Abomonated;
+    ///
+    /// // create some test data out of abomonation-approved types
+    /// let vector = (0..256u64).map(|i| (i, format!("{}", i)))
+    ///                         .collect::<Vec<_>>();
+    ///
+    /// // encode a Vec<(u64, String)> into a Vec<u8>
+    /// let mut bytes = Vec::new();
+    /// unsafe { encode(&vector, &mut bytes); }
+    ///
+    /// // attempt to decode `bytes` into a `&Vec<(u64, String)>`.
+    /// let maybe_decoded = unsafe { Abomonated::<Vec<(u64, String)>,_>::new(bytes) };
+    ///
+    /// if let Some(decoded) = maybe_decoded {
+    ///     // each `deref()` call is now just a pointer cast.
+    ///     assert!(decoded.deref() == &vector);
+    /// }
+    /// else {
+    ///     panic!("failed to decode");
+    /// }
+    /// ```
+    pub unsafe fn new(mut bytes: S) -> Option<Self> {
+
+        // performs the underlying pointer correction, indicates success.
+        let decoded = decode::<T>(bytes.deref_mut()).is_some();
+
+        if decoded {
+            Some(Abomonated {
+                phantom: PhantomData,
+                decoded: bytes,
+            })
+        }
+        else {
+            None
+        }
+    }
+}
+
+impl<T: Abomonation, S: DerefMut<Target=[u8]>> Deref for Abomonated<T, S> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        let result: &T = unsafe { transmute(self.decoded.get_unchecked(0)) };
+        result
+    }
+}

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,0 +1,106 @@
+use ::std::mem::size_of;
+use super::Abomonation;
+
+/// Analogue of `unsafe_abomonate` to additionally implement `AbomonationSize`.
+#[macro_export]
+macro_rules! unsafe_abomonate_size {
+    ($t:ty) => { 
+        impl Abomonation for $t { } 
+        impl AbomonationSize for $t { }
+    };
+    ($t:ty : $($field:ident),*) => {
+        impl Abomonation for $t {
+            #[inline] unsafe fn entomb(&self, _writer: &mut Vec<u8>) {
+                $( self.$field.entomb(_writer); )*
+            }
+            #[inline] unsafe fn embalm(&mut self) {
+                $( self.$field.embalm(); )*
+            }
+            #[inline] unsafe fn exhume<'a,'b>(&'a mut self, mut bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
+                $( let temp = bytes; bytes = if let Some(bytes) = self.$field.exhume(temp) { bytes} else { return None }; )*
+                Some(bytes)
+            }
+        }
+        impl AbomonationSize for $t {
+            #[inline] fn extent(&self) -> usize {
+                let mut size = 0;
+                $( size += self.$field.extent(); )*
+                size
+            }
+        }
+    };
+}
+
+/// Sizing information for typed data in number of bytes required.a
+pub trait AbomonationSize: Abomonation + ::std::marker::Sized {
+    /// Reports the number of further bytes required to entomb `self`.
+    #[inline(always)] fn extent(&self) -> usize { 0 }
+
+    /// Reports the number of bytes required to encode `self`.
+    #[inline(always)]
+    fn measure(&self) -> usize {
+        size_of::<Self>() + self.extent()
+    }
+}
+
+impl AbomonationSize for u8 { }
+impl AbomonationSize for u16 { }
+impl AbomonationSize for u32 { }
+impl AbomonationSize for u64 { }
+impl AbomonationSize for usize { }
+
+impl AbomonationSize for i8 { }
+impl AbomonationSize for i16 { }
+impl AbomonationSize for i32 { }
+impl AbomonationSize for i64 { }
+impl AbomonationSize for isize { }
+
+impl AbomonationSize for f32 { }
+impl AbomonationSize for f64 { }
+
+impl AbomonationSize for bool { }
+impl AbomonationSize for () { }
+
+impl AbomonationSize for char { }
+
+impl<T> AbomonationSize for ::std::marker::PhantomData<T> {}
+
+impl<T: AbomonationSize> AbomonationSize for Option<T> {
+    #[inline] fn extent(&self) -> usize {
+        self.as_ref().map(|inner| inner.extent()).unwrap_or(0)
+    }
+}
+
+impl<T: AbomonationSize, E: AbomonationSize> AbomonationSize for Result<T, E> {
+    #[inline] fn extent(&self) -> usize {
+        match self {
+            &Ok(ref inner) => inner.extent(),
+            &Err(ref inner) => inner.extent(),
+        }
+    }
+}
+
+impl AbomonationSize for String {
+    #[inline] fn extent(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: AbomonationSize> AbomonationSize for Vec<T> {
+    #[inline] fn extent(&self) -> usize {
+        let mut sum = size_of::<T>() * self.len();
+        // let mut sum = typed_to_bytes(&self[..]).len();
+        for element in self.iter() {
+            sum += element.extent();
+        }
+        sum
+    }
+}
+
+impl<T: AbomonationSize> AbomonationSize for Box<T> {
+    #[inline] fn extent(&self) -> usize {
+        size_of::<T>() + (&**self).extent()
+        // ::std::slice::from_raw_parts::<u8>(::std::mem::transmute(&**self), size_of::<T>()).len() + (&**self).extent()
+        // size_of::<Self>() + (&**self).extent()
+    }
+}


### PR DESCRIPTION
This PR adds two new modules

* `size`: Includes a new `AbomonationSize` trait which provides a method `measure` which reports the number of bytes that would be required to `encode` the associated data. The trait is separate from `Abomonation` so as not to break implementations of the trait that do not know about the new methods. They could be integrated in some future breaking build.

* `abomonated`: includes a new type `Abomonated<T, S>` for `T: Abomonation` and `S: DerefMut<Target=[u8]>`, which performs `decode` on construction and implements `Deref<Target=T>` using `transmute`. This allows us to wrap up owned mutable bytes and treat them as if they were the type `T`, without constant `decode` calls that would re-validate all of the data.