### PR TITLE
Support Write trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abomonation"
-version = "0.4.7"
+version = "0.5.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 description = "A high performance and very unsafe serialization library"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -12,6 +12,9 @@ use test::Bencher;
 #[bench] fn u64_enc(bencher: &mut Bencher) { _bench_enc(bencher, vec![0u64; 1024]); }
 #[bench] fn u64_dec(bencher: &mut Bencher) { _bench_dec(bencher, vec![0u64; 1024]); }
 
+#[bench] fn u32x2_enc(bencher: &mut Bencher) { _bench_enc(bencher, vec![(0u32,0u32); 1024]); }
+#[bench] fn u32x2_dec(bencher: &mut Bencher) { _bench_dec(bencher, vec![(0u32,0u32); 1024]); }
+
 #[bench] fn u8_u64_enc(bencher: &mut Bencher) { _bench_enc(bencher, vec![(0u8, 0u64); 512]); }
 #[bench] fn u8_u64_dec(bencher: &mut Bencher) { _bench_dec(bencher, vec![(0u8, 0u64); 512]); }
 
@@ -31,13 +34,13 @@ fn _bench_enc<T: Abomonation>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data for bencher.bytes
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // repeatedly encode this many bytes
     bencher.bytes = bytes.len() as u64;
     bencher.iter(|| {
         bytes.clear();
-        unsafe { encode(&record, &mut bytes) }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
     });
 }
 
@@ -45,7 +48,7 @@ fn _bench_dec<T: Abomonation+Eq>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // repeatedly decode (and validate)
     bencher.bytes = bytes.len() as u64;

--- a/benches/clone.rs
+++ b/benches/clone.rs
@@ -31,13 +31,13 @@ fn _bench_e_d<T: Abomonation>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data for bencher.bytes
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // repeatedly encode this many bytes
     bencher.bytes = bytes.len() as u64;
     bencher.iter(|| {
         bytes = vec![];
-        unsafe { encode(&record, &mut bytes) }
+        unsafe { encode(&record, &mut bytes).unwrap(); }
         unsafe { decode::<T>(&mut bytes) }.is_some()
     });
 }
@@ -46,7 +46,7 @@ fn _bench_cln<T: Abomonation+Clone>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // repeatedly decode (and validate)
     bencher.bytes = bytes.len() as u64;

--- a/benches/recycler.rs
+++ b/benches/recycler.rs
@@ -7,7 +7,7 @@ extern crate test;
 use recycler::{Recyclable, Recycler, make_recycler};
 use abomonation::*;
 use test::Bencher;
-use std::io::Read;
+// use std::io::Read;
 
 #[bench] fn empty_own(bencher: &mut Bencher) { _bench_own(bencher, vec![(); 1024]); }
 #[bench] fn u64_own(bencher: &mut Bencher) { _bench_own(bencher, vec![0u64; 1024]); }
@@ -31,7 +31,7 @@ fn _bench_own<T: Abomonation+Clone>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // repeatedly decode (and validate)
     bencher.bytes = bytes.len() as u64;
@@ -46,7 +46,7 @@ fn _bench_rec<T: Abomonation+Recyclable>(bencher: &mut Bencher, record: T) {
 
     // prepare encoded data
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
     let mut recycler = make_recycler::<T>();
     recycler.recycle(record);
 

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -17,11 +17,11 @@ fn bench_populate(b: &mut Bencher) {
 fn bench_serialize(b: &mut Bencher) {
     let log = Log::new();
     let mut bytes = vec![];
-    unsafe { encode(&log, &mut bytes); }
+    unsafe { encode(&log, &mut bytes).unwrap(); }
     b.bytes = bytes.len() as u64;
     b.iter(|| {
         bytes.clear();
-        unsafe { encode(&log, &mut bytes); }
+        unsafe { encode(&log, &mut bytes).unwrap(); }
         test::black_box(&bytes);
     });
 }
@@ -30,7 +30,7 @@ fn bench_serialize(b: &mut Bencher) {
 fn bench_deserialize(b: &mut Bencher) {
     let log = Log::new();
     let mut bytes = vec![];
-    unsafe { encode(&log, &mut bytes); }
+    unsafe { encode(&log, &mut bytes).unwrap(); }
     b.bytes = bytes.len() as u64;
     b.iter(|| {
         test::black_box(unsafe { decode::<Log>(&mut bytes) });
@@ -41,7 +41,7 @@ fn bench_deserialize(b: &mut Bencher) {
 fn bench_deserialize_assert(b: &mut Bencher) {
     let log = Log::new();
     let mut bytes = vec![];
-    unsafe { encode(&log, &mut bytes); }
+    unsafe { encode(&log, &mut bytes).unwrap(); }
     b.bytes = bytes.len() as u64;
     b.iter(|| {
         assert!(unsafe { decode::<Log>(&mut bytes) }.unwrap().0 == &log);

--- a/src/size.rs
+++ b/src/size.rs
@@ -10,11 +10,9 @@ macro_rules! unsafe_abomonate_size {
     };
     ($t:ty : $($field:ident),*) => {
         impl Abomonation for $t {
-            #[inline] unsafe fn entomb(&self, _writer: &mut Vec<u8>) {
-                $( self.$field.entomb(_writer); )*
-            }
-            #[inline] unsafe fn embalm(&mut self) {
-                $( self.$field.embalm(); )*
+            #[inline] unsafe fn entomb<W: ::std::io::Write>(&self, write: &mut W) -> ::std::io::Result<()> {
+                $( self.$field.entomb(write)?; )*
+                Ok(())
             }
             #[inline] unsafe fn exhume<'a,'b>(&'a mut self, mut bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
                 $( let temp = bytes; bytes = if let Some(bytes) = self.$field.exhume(temp) { bytes} else { return None }; )*

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -38,7 +38,7 @@ fn test_phantom_data_for_non_abomonatable_type() {
 
 fn _test_pass<T: Abomonation+Eq>(record: T) {
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
     {
         let (result, rest) = unsafe { decode::<T>(&mut bytes[..]) }.unwrap();
         assert!(&record == result);
@@ -48,14 +48,14 @@ fn _test_pass<T: Abomonation+Eq>(record: T) {
 
 fn _test_fail<T: Abomonation>(record: T) {
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
     bytes.pop();
     assert!(unsafe { decode::<T>(&mut bytes[..]) }.is_none());
 }
 
 fn _test_size<T: AbomonationSize>(record: T) {
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
     assert_eq!(bytes.len(), record.measure());
 }
 
@@ -76,7 +76,7 @@ fn test_macro() {
 
     // encode vector into a Vec<u8>
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
 
     // decode a &Vec<(u64, String)> from binary data
     if let Some((result, rest)) = unsafe { decode::<MyStruct>(&mut bytes) } {
@@ -103,7 +103,7 @@ fn test_macro_size() {
 
     // encode vector into a Vec<u8>
     let mut bytes = Vec::new();
-    unsafe { encode(&record, &mut bytes); }
+    unsafe { encode(&record, &mut bytes).unwrap(); }
     assert_eq!(bytes.len(), record.measure());
 }
 
@@ -134,10 +134,10 @@ fn test_macro_size() {
 #[test]
 fn test_multiple_encode_decode() {
     let mut bytes = Vec::new();
-    unsafe { encode(&0u32, &mut bytes); }
-    unsafe { encode(&7u64, &mut bytes); }
-    unsafe { encode(&vec![1,2,3], &mut bytes); }
-    unsafe { encode(&"grawwwwrr".to_owned(), &mut bytes); }
+    unsafe { encode(&0u32, &mut bytes).unwrap(); }
+    unsafe { encode(&7u64, &mut bytes).unwrap(); }
+    unsafe { encode(&vec![1,2,3], &mut bytes).unwrap(); }
+    unsafe { encode(&"grawwwwrr".to_owned(), &mut bytes).unwrap(); }
 
     let (t, r) = unsafe { decode::<u32>(&mut bytes) }.unwrap(); assert!(*t == 0);
     let (t, r) = unsafe { decode::<u64>(r) }.unwrap(); assert!(*t == 7);


### PR DESCRIPTION
This PR is a major version bump, and is a breaking change in a bunch of ways. The most significant is that `encode` and `entomb` are both generic with respect to a `W: Write`, and return an `::std::io::Result<()>` rather than nothing at all. The second most significant is that `embalm` doesn't exist any more, and that was the method that cleaned up your pointers to avoid leaking info about your memory addresses. 

These two were fundamentally in conflict, and the second was also in conflict with performance (as we will see). I'm open to thoughts on their reconciliation; `embalm` is not conceptually complicated, it just requires post memcpy write access to the writer.

Most of this PR is simplification and result propagation. There are some performance wins in the benchmarks, presumably due to not having to return to the data to overwrite addresses. The benchmarks should be unaffected on the decode side, as no code was changed there. Other than not erasing addresses, the formats should be the same too (equivalent to in memory representation).

Here are the benchmark changes in `bench.rs`:

| benchmark | old | new |
|-----------:|----:|-----:|
| empty_enc | 3428 MB/s | 24000 MB/s | 
| string10_enc | 4360 MB/s | 6320 MB/s |
| string20_enc | 6050 MB/s | 9042 MB/s |
| u64_enc | 58685 MB/s | 67900 MB/s |
| u8_u64_enc | 60411 MB/s | 57454 MB/s |
| vec_u_s_enc | 5639 MB/s | 8408 MB/s |
| vec_u_vn_s_enc | 5543 MB/s | 10378 MB/s |

And the changes in `serde.rs`:

| benchmark | old | new |
|-----------:|----:|-----:|
| bench_serialize | 6469 MB/s | 10274 MB/s |

These are pretty decent improvements where there were pointers to update, and the only "regression" is `u8_u64`, which I have to imagine is just down to randomness.

At the same time, we should now be able to `encode` into types other than `Vec<u8>`, including but not limited to `&mut [u8]`, `File`, `TcpStream`, and other friends. Note that `&mut [u8]` will error if it isn't large enough to hold the results, and so you should use the new `AbomonationSize` trait to be sure that it is before calling `encode`.